### PR TITLE
更新日付を表示するオプションで、正しい日付が表示されない #1

### DIFF
--- a/inc/wp-show-update-date.php
+++ b/inc/wp-show-update-date.php
@@ -1,8 +1,8 @@
 <?php
 // replace update date
-function change_modified($post)
+function change_modified( $value, $format, $post ) {
 {
-    $post_id = get_the_ID($post);
+    $post_id = $post->ID;
     $publish_date = get_the_time('Ymd', $post_id);
     $update_date = get_the_modified_date('Ymd', $post_id);
 


### PR DESCRIPTION
引数とpost_idの取得方法を修正